### PR TITLE
Ensure documented output matches valid YAML syntax

### DIFF
--- a/.github/workflows/detect-changed-files.yml
+++ b/.github/workflows/detect-changed-files.yml
@@ -41,7 +41,7 @@ jobs:
           list-files: shell
           filters: |
             added_or_modified:
-              - added|modified: '**/*'
+              - added|modified: '**'
             github_actions:
               - added|modified: .github/workflows/*.yml
             markdown:

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ changed files.
 #### Outputs
 
 - For each filter, it sets an output variable named by the filter to the text:
-  - `"true"` - if **any** of changed files matches any of filter rules
-  - `"false"` - if **none** of changed files matches any of filter rules
+  - `'true'` - if **any** of changed files matches any of filter rules
+  - `'false'` - if **none** of changed files matches any of filter rules
 - For each filter, it sets an output variable with the name
   `${FILTER_NAME}_files`. It will contain a list of all files matching the
   filter.


### PR DESCRIPTION
These return values _must_ use single quotes, or the workflow will return an unexpected symbol and be marked as invalid...let's make sure the documentation matches that expectation.