### PR TITLE
Cache actionlint on pushes to the main branch

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -9,8 +9,6 @@ name: push to main
   workflow_dispatch:
 
 jobs:
-  detect_changed_files:
-    name: detect changed files
-    permissions:
-      pull-requests: read
-    uses: ./.github/workflows/detect-changed-files.yml
+  cache_actionlint:
+    name: cache actionlint
+    uses: ./.github/workflows/preload-cache-actionlint.yml

--- a/.github/workflows/on-schedule-weekly.yml
+++ b/.github/workflows/on-schedule-weekly.yml
@@ -5,6 +5,9 @@ name: schedule weekly
     # Run every Monday at 7:45am UTC.
     - cron: 45 7 * * 1
 
+  # Allow manually running this workflow.
+  workflow_dispatch:
+
 jobs:
   cache_actionlint:
     name: cache actionlint


### PR DESCRIPTION
Also, most jobs that aren't tied to a pull request can probably have a manual trigger option available as well.