### PR TITLE
Prevent deployment_perms_error due to file permissions

### DIFF
--- a/.github/workflows/deploy-github-pages-rust.yml
+++ b/.github/workflows/deploy-github-pages-rust.yml
@@ -24,6 +24,9 @@ jobs:
         env:
           RUSTDOCFLAGS: --enable-index-page -Z unstable-options
         run: cargo +nightly doc --no-deps
+      # prevent deployment_perms_error due to file permissions
+      - name: Remove lock file
+        run: rm target/doc/.lock
       - name: Upload github-pages artifact
         uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c
         with:


### PR DESCRIPTION
When deploying to GitHub Pages, it expects that all files have read permissions for "others" (e.g. `0644`), but rustdoc generates an empty lock file that's set to `0700` which will cause an error when trying to deploy the artifact.

The upload-pages-artifact action used to handle changing the file permissions directly, but removed the feature in the latest v2.0.0 major release due to the performance impact on large repositories.

To work around the issue in our case, we can simply remove this empty file.

See:
- https://github.com/actions/upload-pages-artifact#file-permissions