### PR TITLE
Use plural caches instead of singular cache

### DIFF
--- a/.github/workflows/call-flush-caches.yml
+++ b/.github/workflows/call-flush-caches.yml
@@ -1,12 +1,12 @@
-name: call flush cache
+name: call flush caches
 
 on:
   # Allow manually running this workflow.
   workflow_dispatch:
 
 jobs:
-  flush_cache:
-    name: flush cache
+  flush_caches:
+    name: flush caches
     permissions:
       actions: write
-    uses: ./.github/workflows/flush-cache.yml
+    uses: ./.github/workflows/flush-caches.yml

--- a/.github/workflows/call-preload-caches.yml
+++ b/.github/workflows/call-preload-caches.yml
@@ -1,11 +1,9 @@
-name: call preload cache
+name: call preload caches
 
 on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/*.yml
 
   schedule:
     # Run every Monday at 7:45am UTC.
@@ -21,4 +19,4 @@ concurrency:
 jobs:
   cache_actionlint:
     name: cache actionlint
-    uses: ./.github/workflows/preload-cache-actionlint.yml
+    uses: ./.github/workflows/preload-caches-actionlint.yml

--- a/.github/workflows/flush-caches.yml
+++ b/.github/workflows/flush-caches.yml
@@ -1,4 +1,4 @@
-name: flush cache
+name: flush caches
 
 on:
   workflow_call:

--- a/.github/workflows/on-schedule-weekly.yml
+++ b/.github/workflows/on-schedule-weekly.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   cache_actionlint:
     name: cache actionlint
-    uses: ./.github/workflows/preload-cache-actionlint.yml
+    uses: ./.github/workflows/preload-caches-actionlint.yml

--- a/.github/workflows/preload-caches-actionlint.yml
+++ b/.github/workflows/preload-caches-actionlint.yml
@@ -1,4 +1,4 @@
-name: preload cache / actionlint
+name: preload caches / actionlint
 
 on:
   workflow_call:

--- a/.github/workflows/preload-caches-rust.yml
+++ b/.github/workflows/preload-caches-rust.yml
@@ -1,4 +1,4 @@
-name: preload cache / rust
+name: preload caches / rust
 
 on:
   workflow_call:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ jobs:
 
 ---
 
-### flush-cache.yml
+### flush-caches.yml
 
 Deletes all cache entries from the [GitHub Actions cache][] for the current
 branch.
@@ -176,13 +176,13 @@ that originate from forked repositories.
 
 ---
 
-### preload-cache-actionlint.yml
+### preload-caches-actionlint.yml
 
 Saves the [actionlint][] binary into the [GitHub Actions cache][].
 
 ---
 
-### preload-cache-rust.yml
+### preload-caches-rust.yml
 
 Saves the repository's Rust project dependencies for both the _stable_ and
 _MSRV_ (Minimum Supported Rust Version) toolchains into the [GitHub Actions


### PR DESCRIPTION
This better matches the GitHub Actions interface, for clarity.