### PR TITLE
Tweak job names to account for slashes

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -11,8 +11,8 @@ on:
         default: "latest"
 
 jobs:
-  check_formatting:
-    name: check formatting
+  format:
+    name: format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/check-rust-beta.yml
+++ b/.github/workflows/check-rust-beta.yml
@@ -1,4 +1,4 @@
-name: check rust beta
+name: check rust / beta
 
 on:
   workflow_call:
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test_beta:
-    name: test / beta
+    name: test beta
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/check-rust-miri.yml
+++ b/.github/workflows/check-rust-miri.yml
@@ -1,4 +1,4 @@
-name: check rust miri
+name: check rust / miri
 
 on:
   workflow_call:
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test_miri:
-    name: test / miri
+    name: test miri
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo clippy --locked --all-targets -- -D warnings
 
   test_stable:
-    name: test / stable
+    name: test stable
     needs:
       - format
       - lint
@@ -83,7 +83,7 @@ jobs:
         run: cargo test --locked --doc
 
   test_msrv:
-    name: test / msrv
+    name: test msrv
     needs:
       - format
       - lint

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -8,8 +8,8 @@ on:
         default: "."
 
 jobs:
-  check_for_typos:
-    name: check for typos
+  find_typos:
+    name: find typos
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code


### PR DESCRIPTION
GitHub displays jobs slightly differently depending on the names when slashes are involved.