### PR TITLE
Use "auto-" prefix for jobs triggered automatically

### DIFF
--- a/.github/workflows/auto-label-pull-request.yml
+++ b/.github/workflows/auto-label-pull-request.yml
@@ -1,4 +1,4 @@
-name: on pull request target
+name: auto-label pull request
 
 on:
   pull_request_target:


### PR DESCRIPTION
Trying the new convention, although this repository is a bit weird due to the mixture of both reusable and repo-specific workflows existing together.