### PR TITLE
Have dependabot ignore the typos action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: weekly
     groups:
-      github-actions-dependencies:
+      dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - typos


### PR DESCRIPTION
This project exists in a monorepo where dependabot cannot determine the correct latest tag for the project. Now that we're grouping updates, we need to explicitly ignore 'typos' and will update it manually.