### PR TITLE
Adjust workflows based on upstream breaking changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,9 @@
 # See https://github.com/actions/labeler for more information.
 
 documentation:
-  - "**/*.md"
+  - changed-files:
+      - any-glob-to-any-file: "**/*.md"
 
 github_actions:
-  - .github/workflows/*.yml
+  - changed-files:
+      - any-glob-to-any-file: .github/workflows/*.yml

--- a/.github/workflows/deploy-github-pages-rust.yml
+++ b/.github/workflows/deploy-github-pages-rust.yml
@@ -35,6 +35,7 @@ jobs:
   deploy_docs_artifact:
     name: deploy docs artifact
     permissions:
+      actions: read
       id-token: write
       pages: write
     needs: build_docs


### PR DESCRIPTION
I expect that this may fail on the labeler change since we've already bumped the action version and it gets run from the base branch rather than the HEAD of the Pull Request. That's okay.