### PR TITLE
Use built-in gh cli instead of third-party action for release step

### DIFF
--- a/.github/workflows/draft-release-flutter.yml
+++ b/.github/workflows/draft-release-flutter.yml
@@ -90,11 +90,13 @@ jobs:
 
       - id: gh_release
         name: Create a new GitHub draft release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         if: github.ref_type == 'tag'
-        with:
-          draft: true
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --draft \
+            --generate-notes
 
       - name: Annotate workflow run with draft release URL
         env:

--- a/.github/workflows/draft-release-rust.yml
+++ b/.github/workflows/draft-release-rust.yml
@@ -32,10 +32,13 @@ jobs:
 
       - id: gh_release
         name: Create a new GitHub draft release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
-        with:
-          draft: true
-          generate_release_notes: true
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --draft \
+            --generate-notes
 
       - name: Annotate workflow run with draft release URL
         env:


### PR DESCRIPTION
Addresses the warning from zizmor:

```
info[superfluous-actions]: action functionality is already included by the runner
  --> ./.github/workflows/draft-release-flutter.yml:93:15
   |
92 |         name: Create a new GitHub draft release
   |         --------------------------------------- this step
93 |         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use `gh release` in a script step
   |
   = note: audit confidence → High
```