### PR TITLE
Do not update dependencies when bumping versions

### DIFF
--- a/.github/workflows/bump-version-flutter-app.yml
+++ b/.github/workflows/bump-version-flutter-app.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Install dependencies
         run: flutter pub get --enforce-lockfile
 
-      - name: Update dependencies
-        run: flutter pub upgrade --unlock-transitive
-
       - name: Bump CalVer version for project
         env:
           INPUTS_FORMAT: ${{ inputs.format }}

--- a/.github/workflows/bump-version-rust.yml
+++ b/.github/workflows/bump-version-rust.yml
@@ -81,11 +81,6 @@ jobs:
         with:
           tool: cargo-release
 
-      - name: Update cargo dependencies for package ${{ inputs.package }}
-        env:
-          INPUTS_PACKAGE: ${{ inputs.package }}
-        run: cargo update --package "${INPUTS_PACKAGE}"
-
       - name: Bump ${{ inputs.level }} version for package ${{ inputs.package }}
         env:
           INPUTS_PACKAGE: ${{ inputs.package }}


### PR DESCRIPTION
Yes, we do run automated tests with the new versions, but there is a concern about supply chain security here. I'd rather explicitly rely on our Dependabot pull requests that have a cooldown period configured to not accidentally include an insecure update when cutting a release.