### PR TITLE
Limit GitHub App token permissions in workflows

### DIFF
--- a/.github/workflows/bump-version-flutter-app.yml
+++ b/.github/workflows/bump-version-flutter-app.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/bump-version-flutter-lib.yml
+++ b/.github/workflows/bump-version-flutter-lib.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/bump-version-rust.yml
+++ b/.github/workflows/bump-version-rust.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/tag-if-missing.yml
+++ b/.github/workflows/tag-if-missing.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/tag-untagged-releases-rust.yml
+++ b/.github/workflows/tag-untagged-releases-rust.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
Request contents: write for all create-github-app-token call sites because the generated token is used for checkout and for writing repository refs.

Also request pull-requests: write in the version bump workflows because the same token is passed to peter-evans/create-pull-request to open release PRs.

The tag workflows only create or push Git tags, so contents: write is enough there.