### PR TITLE
Check local Dart packages in the Flutter workflow

### DIFF
--- a/.github/workflows/check-flutter.yml
+++ b/.github/workflows/check-flutter.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Check lints
         run: flutter analyze
 
+      - name: Check local package lints
+        run: |
+          set -euo pipefail
+          for package in packages/*/; do
+            [ -f "${package}pubspec.yaml" ] || continue
+            (cd "$package" && dart pub get && dart analyze --fatal-infos)
+          done
+
   test:
     name: test
     runs-on: ubuntu-latest
@@ -69,3 +77,15 @@ jobs:
 
       - name: Run tests
         run: flutter test
+
+      - name: Run local package tests
+        run: |
+          set -euo pipefail
+          for package in packages/*/; do
+            [ -d "${package}test" ] || continue
+            if grep -qE '^\s+sdk:\s*flutter\s*$' "${package}pubspec.yaml"; then
+              (cd "$package" && flutter pub get && flutter test)
+            else
+              (cd "$package" && dart pub get && dart test)
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Details: [docs/common.md](docs/common.md)
 
 Workflows specific to Flutter projects:
 
-- `check-flutter.yml` – Format, analyze, and test using pinned Flutter
+- `check-flutter.yml` – Format, analyze, and test using pinned Flutter,
+  including any local packages under `packages/`
 - `preload-caches-flutter.yml` – Cache pinned Flutter dependencies
 - `bump-version-flutter-app.yml` – Bump CalVer version and changelog, open PR
 - `bump-version-flutter-lib.yml` – Bump SemVer version and changelog, open PR


### PR DESCRIPTION
Extend check-flutter.yml to analyze and test any local packages under packages/: the lint job runs dart analyze --fatal-infos and the test job runs dart test in each package directory. Repos without local packages are unaffected.